### PR TITLE
Don't explicitly mention site.name in HTML templates

### DIFF
--- a/girder_auth_design/core/templates/account/login.html
+++ b/girder_auth_design/core/templates/account/login.html
@@ -11,9 +11,9 @@
 {% get_providers as socialaccount_providers %}
 {% if socialaccount_providers %}
 <p>
-  {% blocktrans with site.name as site_name %}
+  {% blocktrans trimmed %}
   Please sign in with one of your existing third party accounts.
-  Or, <a href="{{ signup_url }}">sign up</a> for a {{ site_name }} account and sign in below:
+  Or, <a href="{{ signup_url }}">sign up</a> for an account and sign in below:
   {% endblocktrans %}
 </p>
 <div class="socialaccount_ballot">


### PR DESCRIPTION
There's only one place that "site.name" is mentioned, and it's not strictly required. Since "site.name" may not be properly configured in some projects, it's safer to omit.